### PR TITLE
Add announcement board with Spring MVC and Hibernate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <packaging>war</packaging>
 
     <properties>
-        <java.version>11</java.version>
-        <spring.version>5.3.30</spring.version>
-        <hibernate.version>5.6.15.Final</hibernate.version>
+        <java.version>17</java.version>
+        <spring.version>6.0.13</spring.version>
+        <hibernate.version>6.2.6.Final</hibernate.version>
     </properties>
 
     <dependencies>
@@ -26,36 +26,41 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.2.224</version>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <version>2.3.3</version>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-            <version>1.2</version>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.1.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/example/controller/AnnouncementController.java
+++ b/src/main/java/com/example/controller/AnnouncementController.java
@@ -1,0 +1,58 @@
+package com.example.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.model.Announcement;
+import com.example.service.AnnouncementService;
+
+@Controller
+@RequestMapping("/announcements")
+public class AnnouncementController {
+
+    @Autowired
+    private AnnouncementService announcementService;
+
+    @GetMapping
+    public String list(@RequestParam(defaultValue = "1") int page, Model model) {
+        int size = 5;
+        model.addAttribute("announcements", announcementService.list(page, size));
+        long total = announcementService.count();
+        int totalPages = (int) Math.ceil((double) total / size);
+        model.addAttribute("page", page);
+        model.addAttribute("totalPages", totalPages);
+        return "announcements";
+    }
+
+    @GetMapping("/new")
+    public String create(Model model) {
+        model.addAttribute("announcement", new Announcement());
+        return "announcement_form";
+    }
+
+    @PostMapping("/save")
+    public String save(@ModelAttribute("announcement") Announcement announcement) {
+        announcementService.save(announcement);
+        return "redirect:/announcements";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String edit(@PathVariable Long id, Model model) {
+        model.addAttribute("announcement", announcementService.get(id));
+        return "announcement_form";
+    }
+
+    @GetMapping("/delete/{id}")
+    public String delete(@PathVariable Long id) {
+        announcementService.delete(id);
+        return "redirect:/announcements";
+    }
+}
+

--- a/src/main/java/com/example/dao/AnnouncementDao.java
+++ b/src/main/java/com/example/dao/AnnouncementDao.java
@@ -1,0 +1,14 @@
+package com.example.dao;
+
+import java.util.List;
+
+import com.example.model.Announcement;
+
+public interface AnnouncementDao {
+    void save(Announcement announcement);
+    Announcement get(Long id);
+    List<Announcement> list(int page, int size);
+    long count();
+    void delete(Long id);
+}
+

--- a/src/main/java/com/example/dao/AnnouncementDaoImpl.java
+++ b/src/main/java/com/example/dao/AnnouncementDaoImpl.java
@@ -1,0 +1,51 @@
+package com.example.dao;
+
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import com.example.model.Announcement;
+
+@Repository
+public class AnnouncementDaoImpl implements AnnouncementDao {
+
+    @Autowired
+    private SessionFactory sessionFactory;
+
+    @Override
+    public void save(Announcement announcement) {
+        sessionFactory.getCurrentSession().saveOrUpdate(announcement);
+    }
+
+    @Override
+    public Announcement get(Long id) {
+        return sessionFactory.getCurrentSession().get(Announcement.class, id);
+    }
+
+    @Override
+    public List<Announcement> list(int page, int size) {
+        return sessionFactory.getCurrentSession()
+                .createQuery("from Announcement order by publishDate desc", Announcement.class)
+                .setFirstResult((page - 1) * size)
+                .setMaxResults(size)
+                .list();
+    }
+
+    @Override
+    public long count() {
+        return sessionFactory.getCurrentSession()
+                .createQuery("select count(*) from Announcement", Long.class)
+                .uniqueResult();
+    }
+
+    @Override
+    public void delete(Long id) {
+        Announcement announcement = get(id);
+        if (announcement != null) {
+            sessionFactory.getCurrentSession().delete(announcement);
+        }
+    }
+}
+

--- a/src/main/java/com/example/model/Announcement.java
+++ b/src/main/java/com/example/model/Announcement.java
@@ -1,0 +1,85 @@
+package com.example.model;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "announcements")
+public class Announcement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String publisher;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate publishDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate deadline;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+        this.publisher = publisher;
+    }
+
+    public LocalDate getPublishDate() {
+        return publishDate;
+    }
+
+    public void setPublishDate(LocalDate publishDate) {
+        this.publishDate = publishDate;
+    }
+
+    public LocalDate getDeadline() {
+        return deadline;
+    }
+
+    public void setDeadline(LocalDate deadline) {
+        this.deadline = deadline;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}
+

--- a/src/main/java/com/example/model/User.java
+++ b/src/main/java/com/example/model/User.java
@@ -1,10 +1,10 @@
 package com.example.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "users")

--- a/src/main/java/com/example/service/AnnouncementService.java
+++ b/src/main/java/com/example/service/AnnouncementService.java
@@ -1,0 +1,14 @@
+package com.example.service;
+
+import java.util.List;
+
+import com.example.model.Announcement;
+
+public interface AnnouncementService {
+    void save(Announcement announcement);
+    Announcement get(Long id);
+    List<Announcement> list(int page, int size);
+    long count();
+    void delete(Long id);
+}
+

--- a/src/main/java/com/example/service/AnnouncementServiceImpl.java
+++ b/src/main/java/com/example/service/AnnouncementServiceImpl.java
@@ -1,0 +1,44 @@
+package com.example.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.dao.AnnouncementDao;
+import com.example.model.Announcement;
+
+@Service
+@Transactional
+public class AnnouncementServiceImpl implements AnnouncementService {
+
+    @Autowired
+    private AnnouncementDao announcementDao;
+
+    @Override
+    public void save(Announcement announcement) {
+        announcementDao.save(announcement);
+    }
+
+    @Override
+    public Announcement get(Long id) {
+        return announcementDao.get(id);
+    }
+
+    @Override
+    public List<Announcement> list(int page, int size) {
+        return announcementDao.list(page, size);
+    }
+
+    @Override
+    public long count() {
+        return announcementDao.count();
+    }
+
+    @Override
+    public void delete(Long id) {
+        announcementDao.delete(id);
+    }
+}
+

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -10,10 +10,10 @@
     <context:component-scan base-package="com.example"/>
 
     <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="org.h2.Driver"/>
-        <property name="url" value="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1"/>
-        <property name="username" value="sa"/>
-        <property name="password" value=""/>
+        <property name="driverClassName" value="com.mysql.cj.jdbc.Driver"/>
+        <property name="url" value="jdbc:mysql://localhost:3306/bulletin?useSSL=false&amp;serverTimezone=UTC"/>
+        <property name="username" value="root"/>
+        <property name="password" value="password"/>
     </bean>
 
     <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
@@ -21,7 +21,7 @@
         <property name="packagesToScan" value="com.example.model"/>
         <property name="hibernateProperties">
             <props>
-                <prop key="hibernate.dialect">org.hibernate.dialect.H2Dialect</prop>
+                <prop key="hibernate.dialect">org.hibernate.dialect.MySQL8Dialect</prop>
                 <prop key="hibernate.hbm2ddl.auto">update</prop>
                 <prop key="hibernate.show_sql">true</prop>
             </props>

--- a/src/main/webapp/WEB-INF/jsp/announcement_form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/announcement_form.jsp
@@ -1,0 +1,44 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <title>${announcement.id == null ? '新增公告' : '修改公告'}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="container mt-4">
+<h1>${announcement.id == null ? '新增公告' : '修改公告'}</h1>
+<form method="post" action="${pageContext.request.contextPath}/announcements/save">
+    <input type="hidden" name="id" value="${announcement.id}"/>
+
+    <div class="mb-3">
+        <label class="form-label">標題</label>
+        <input class="form-control" type="text" name="title" value="${announcement.title}" required/>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">公布者</label>
+        <input class="form-control" type="text" name="publisher" value="${announcement.publisher}" required/>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">發佈日期</label>
+        <input class="form-control" type="date" name="publishDate" value="${announcement.publishDate}" required/>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">截止日期</label>
+        <input class="form-control" type="date" name="deadline" value="${announcement.deadline}"/>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">公布內容</label>
+        <textarea class="form-control" name="content" rows="5">${announcement.content}</textarea>
+    </div>
+
+    <button type="submit" class="btn btn-primary">儲存</button>
+    <a class="btn btn-secondary" href="${pageContext.request.contextPath}/announcements">取消</a>
+</form>
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/jsp/announcements.jsp
+++ b/src/main/webapp/WEB-INF/jsp/announcements.jsp
@@ -1,0 +1,51 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <title>公告列表</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="container mt-4">
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>公告列表</h1>
+    <a class="btn btn-primary" href="${pageContext.request.contextPath}/announcements/new">新增公告</a>
+</div>
+
+<table class="table table-striped">
+    <thead>
+    <tr>
+        <th>標題</th>
+        <th>發佈日期</th>
+        <th>截止日期</th>
+        <th>操作</th>
+    </tr>
+    </thead>
+    <tbody>
+    <c:forEach var="ann" items="${announcements}">
+        <tr>
+            <td>${ann.title}</td>
+            <td>${ann.publishDate}</td>
+            <td>${ann.deadline}</td>
+            <td>
+                <a class="btn btn-sm btn-secondary" href="${pageContext.request.contextPath}/announcements/edit/${ann.id}">修改</a>
+                <a class="btn btn-sm btn-danger" href="${pageContext.request.contextPath}/announcements/delete/${ann.id}" onclick="return confirm('確定刪除?');">刪除</a>
+            </td>
+        </tr>
+    </c:forEach>
+    </tbody>
+</table>
+
+<nav>
+    <ul class="pagination">
+        <c:forEach var="i" begin="1" end="${totalPages}">
+            <li class="page-item ${i == page ? 'active' : ''}">
+                <a class="page-link" href="${pageContext.request.contextPath}/announcements?page=${i}">${i}</a>
+            </li>
+        </c:forEach>
+    </ul>
+ </nav>
+
+</body>
+</html>
+

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-         version="3.1">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <display-name>Spring MVC Hibernate Demo</display-name>
 

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,1 +1,1 @@
-<jsp:forward page="/"/>
+<jsp:forward page="/announcements"/>


### PR DESCRIPTION
## Summary
- upgrade project to Java 17, Spring 6, Hibernate 6 and switch to Jakarta EE & MySQL
- implement `Announcement` entity, DAO, service and controller for CRUD operations with pagination
- add Bootstrap-based JSP views for listing and editing announcements

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f9084cd288326bbfbe7cc339b22e4